### PR TITLE
Add uvicorn import to api_server.py for server execution

### DIFF
--- a/api_server.py
+++ b/api_server.py
@@ -16,6 +16,7 @@ sys.path.insert(0, '.')
 
 import numpy as np
 from fastapi import FastAPI, HTTPException, UploadFile, File, BackgroundTasks
+import uvicorn
 from fastapi.middleware.cors import CORSMiddleware  
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field


### PR DESCRIPTION
## Summary
- Adds import of `uvicorn` in `api_server.py` to support running the FastAPI server

## Changes

### Backend
- Imported `uvicorn` in `api_server.py` to enable server execution and management

## Test plan
- Verify that the FastAPI server can be started using `uvicorn` without import errors
- Confirm no impact on existing API functionality

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/bba77bcd-4bd7-4a45-909b-2fe8cbed4a46